### PR TITLE
Change is proxy configurationb

### DIFF
--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -956,7 +956,7 @@ configuration.
     :ref:`string <string-label>`
 
     URL of a proxy server to connect through. Set to an empty string to disable the proxy setting inherited from the main section and use direct connection instead. The expected format of this option is ``<scheme>://<ip-or-hostname>[:port]``.
-    (For backward compatibility, '_none_' can be used instead of the empty string.)
+    (For backward compatibility empty string can be used instead of '_none_' while using yum.conf for proxy configuration.)
 
     Note: The curl environment variables (such as ``http_proxy``) are effective if this option is unset. See the ``curl`` man page for details.
 


### PR DESCRIPTION
# dnf clean all ; dnf list
0 files removed
Yum Repository                                                                                                                 0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'baseos':
  - Curl error (5): Couldn't resolve proxy name for http://test.com/rhel-8-for-x86_64-baseos-rpms/repodata/repomd.xml [Could not resolve proxy: _none_]
Error: Failed to download metadata for repo 'baseos': Cannot download repomd.xml: Curl error (5): Couldn't resolve proxy name for http://test.com/rhel-8-for-x86_64-baseos-rpms/repodata/repomd.xml [Could not resolve proxy: _none_]

yum.conf:

[main]
cachedir=/var/cache/yum/$basearch/$releasever
clean_requirements_on_remove=1
debuglevel=2
exactarch=1
gpgcheck=1
installonly_limit=5
keepcache=0
localpkg_gpgcheck=1
logfile=/var/log/yum.log
obsoletes=1
plugins=1
proxy=_none_  <-- entry causing issue

repo file:

[baseos]
name=Yum Repository
baseurl=http://test.com/rhel-8-for-x86_64-baseos-rpms
enabled=1
gpgcheck=0